### PR TITLE
SpW-R draft 0.4 applied, Shimafuji SpacePi functions added

### DIFF
--- a/includes/SpaceWire.hh
+++ b/includes/SpaceWire.hh
@@ -41,6 +41,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "SpaceWireIF.hh"
 #include "SpaceWireIFOverTCP.hh"
 #include "SpaceWireIFOverIPClient.hh"
+#include "SpaceWireIFOverSPI.hh"
 #include "SpaceWireProtocol.hh"
 #include "SpaceWireSSDTPModule.hh"
 #include "SpaceWireUtilities.hh"

--- a/includes/SpaceWire.hh
+++ b/includes/SpaceWire.hh
@@ -41,9 +41,12 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "SpaceWireIF.hh"
 #include "SpaceWireIFOverTCP.hh"
 #include "SpaceWireIFOverIPClient.hh"
-#include "SpaceWireIFOverSPI.hh"
 #include "SpaceWireProtocol.hh"
 #include "SpaceWireSSDTPModule.hh"
 #include "SpaceWireUtilities.hh"
+
+#if defined(RASPBERRY_PI)
+#include "SpaceWireIFOverSPI.hh"
+#endif
 
 #endif /* SPACEWIRE_HH_ */

--- a/includes/SpaceWireIFOverSPI.hh
+++ b/includes/SpaceWireIFOverSPI.hh
@@ -1,0 +1,204 @@
+/* 
+   ============================================================================
+   SpaceWire/RMAP Library is provided under the MIT License.
+   ============================================================================
+
+   Copyright (c) 2006-2013 Takayuki Yuasa and The Open-source SpaceWire Project
+   Copyright (c) 2020- 
+
+   Permission is hereby granted, free of charge, to any person obtaining a 
+   copy of this software and associated documentation files (the 
+   "Software"), to deal in the Software without restriction, including 
+   without limitation the rights to use, copy, modify, merge, publish, 
+   distribute, sublicense, and/or sell copies of the Software, and to 
+   permit persons to whom the Software is furnished to do so, subject to 
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included 
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF 
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY 
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 
+   */
+/*
+ * SpaceWireIFOverSPI.hh
+ *
+ *  Created on: May 19, 2020
+ *      Author: takada
+ */
+
+#ifndef SPACEWIREIFOVERSPI_HH_
+#define SPACEWIREIFOVERSPI_HH_
+
+#include "CxxUtilities/CxxUtilities.hh"
+
+#include "SpaceWireIF.hh"
+#include "SpaceWireUtilities.hh"
+#include "SpaceWireSpacePiModule.hh"
+
+/** SpaceWire IF class which is connected to a real SpaceWire IF
+ * via SPI interface on SpacePi.
+ */
+class SpaceWireIFOverSPI : public SpaceWireIF, public SpaceWireIFActionTimecodeScynchronizedAction {
+    private:
+        bool opened;
+        SpaceWireSpacePiModule* spacepi;
+
+    public:
+        enum {
+            InitiatorMode, TargetMode
+        };
+
+    private:
+        uint32_t operationMode;
+
+    public:
+        SpaceWireIFOverSPI() :
+            SpaceWireIF() {
+            }
+
+        virtual ~SpaceWireIFOverSPI() {
+        }
+
+    public:
+        void open() throw (SpaceWireIFException) {
+
+            if (state == Opened) {
+                return;
+            }
+
+            spacepi = NULL;
+            spacepi = new SpaceWireSpacePiModule();
+            if(spacepi->open() != 0)
+                state = Closed;
+            else
+                state = Opened;
+        }
+
+        void close() throw (SpaceWireIFException) {
+            using namespace CxxUtilities;
+            using namespace std;
+            if (state == Closed) {
+                return;
+            }
+            state = Closed;
+            //invoke SpaceWireIFCloseActions to tell other instances
+            //closing of this SpaceWire interface
+            invokeSpaceWireIFCloseActions();
+            if(spacepi != NULL){
+                spacepi->close();
+                delete spacepi;
+            }
+
+        }
+
+    public:
+        void send(uint8_t* data, size_t length, SpaceWireEOPMarker::EOPType eopType = SpaceWireEOPMarker::EOP)
+            throw (SpaceWireIFException) {
+                using namespace std;
+                try {
+                    spacepi->send(data, length); // TODO: 
+                } catch (SpaceWireIFException& e) {
+                    throw SpaceWireIFException(SpaceWireIFException::Disconnected);
+                }
+                // dummy wait to avoid buffer bug
+                //usleep(3000);
+            }
+
+    public:
+        void receive(std::vector<uint8_t>* buffer) throw (SpaceWireIFException) {
+            try {
+                uint32_t length, i;
+                uint8_t buf[2056];
+                length = 2056;
+
+                spacepi->receive(&buf[0], &length);
+
+                buffer->resize(length);
+                if(length != 0){  // SPI DATA copy
+                    memcpy(&(buffer->at(0)), buf+2, length);
+                }
+
+               // for(i=2;i<length+2;i++) { 
+               //     printf("%02X ", buf[i]);
+               // }
+               // printf("\n");
+            } catch (SpaceWireSpacePiException& e){
+                if(e.getStatus() == SpaceWireSpacePiException::Timeout){
+                    throw SpaceWireIFException(SpaceWireIFException::Timeout);
+                }
+            } catch (SpaceWireIFException& e) {
+                using namespace std;
+                throw SpaceWireIFException(SpaceWireIFException::Disconnected);
+            }
+        }
+
+    public:
+        void emitTimecode(uint8_t timeIn, uint8_t controlFlagIn = 0x00) throw (SpaceWireIFException) {
+            using namespace std;
+            cerr << "SpaceWireIFOverSPI::emitTimecode() is not implemented." << endl;
+            throw SpaceWireIFException(SpaceWireIFException::FunctionNotImplemented);
+        }
+
+    public:
+        virtual void setTxLinkRate(uint32_t linkRateType) throw (SpaceWireIFException) {
+            using namespace std;
+            cerr << "SpaceWireIFOverSPI::setTxLinkRate() is not implemented." << endl;
+            cerr << "Please use SpaceWireIFOverIPClient::setTxDivCount() instead." << endl;
+            throw SpaceWireIFException(SpaceWireIFException::FunctionNotImplemented);
+        }
+
+        virtual uint32_t getTxLinkRateType() throw (SpaceWireIFException) {
+            using namespace std;
+            cerr << "SpaceWireIFOverSPI::getTxLinkRate() is not implemented." << endl;
+            throw SpaceWireIFException(SpaceWireIFException::FunctionNotImplemented);
+        }
+
+    public:
+        void setTxDivCount(uint8_t txdivcount) {
+            using namespace std;
+            cerr << "SpaceWireIFOverSPI::setTxDivCount() is not implemented." << endl;
+            throw SpaceWireIFException(SpaceWireIFException::FunctionNotImplemented);
+        }
+
+    public:
+        void setTimeoutDuration(double microsecond) throw (SpaceWireIFException) {
+            spacepi->setTimeout(microsecond/1000.);
+            timeoutDurationInMicroSec = microsecond;
+        }
+
+    public:
+        uint8_t getTimeCode() throw (SpaceWireIFException) {
+            using namespace std;
+            cerr << "SpaceWireIFOverSPI::getTimeCode() is not implemented." << endl;
+            throw SpaceWireIFException(SpaceWireIFException::FunctionNotImplemented);
+
+            return 0;  //TODO
+        }
+
+        void doAction(uint8_t timecode) {
+            this->invokeTimecodeSynchronizedActions(timecode);
+        }
+
+    public:
+        uint32_t getOperationMode() const {
+            using namespace std;
+            cerr << "SpaceWireIFOverSPI::getOperationMode() is not implemented." << endl;
+            throw SpaceWireIFException(SpaceWireIFException::FunctionNotImplemented);
+
+            return InitiatorMode;
+        }
+
+
+    public:
+        /** Cancels ongoing receive() method if any exist.
+        */
+        void cancelReceive(){}
+};
+
+#endif /* SPACEWIREIFOVERSPI_HH_ */

--- a/includes/SpaceWireR/SpaceWireREngine.hh
+++ b/includes/SpaceWireR/SpaceWireREngine.hh
@@ -39,10 +39,10 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "SpaceWireR/SpaceWireRClassInterfaces.hh"
 
 //#define SpaceWireREngineDumpPacket
-#define DebugSpaceWireREngine
+//#define DebugSpaceWireREngine
 
 #undef SpaceWireREngineDumpPacket
-//#undef DebugSpaceWireREngine
+#undef DebugSpaceWireREngine
 
 
 /*

--- a/includes/SpaceWireR/SpaceWireRPacket.hh
+++ b/includes/SpaceWireR/SpaceWireRPacket.hh
@@ -654,8 +654,8 @@ public:
 #endif
 				for (size_t i = 0; i < payloadLengthValue; i++) {
 					payload.push_back(buffer->at(index));
+                    index++;
 				}
-				index += payloadLengthValue;
 			} catch (...) {
 				throw SpaceWireRPacketException(SpaceWireRPacketException::InvalidPayloadLength);
 			}

--- a/includes/SpaceWireR/SpaceWireRReceiveTEP.hh
+++ b/includes/SpaceWireR/SpaceWireRReceiveTEP.hh
@@ -706,24 +706,8 @@ private:
 		cout << "SpaceWireRReceiveTEP::processHeartBeatPacket() nHeartBeat = " << nReceivedHeartBeatPackets
 				<< " sequence number = " << (uint32_t) packet->getSequenceNumber() << endl;
 #endif
-
-		if (insideForwardReceiveSlidingWindow(sequenceNumber)) {
-			if (this->receiveSlidingWindowBuffer[sequenceNumber] == NULL) {
-				replyAckForPacket(packet);
-				this->receiveSlidingWindowBuffer[sequenceNumber] = packet;
-				slideReceiveSlidingWindow();
-			} else {
-				replyAckForPacket(packet);
-				delete packet;
-			}
-		} else if (insideBackwardReceiveSlidingWindow(sequenceNumber)) {
-			replyAckForPacket(packet);
-			delete packet;
-		} else {
-			malfunctioningTransportChannel();
-			nDiscardedHeartBeatPackets++;
-		}
-
+		replyAckForPacket(packet);
+    	delete packet;
 	}
 
 private:

--- a/includes/SpaceWireR/SpaceWireRTransmitTEP.hh
+++ b/includes/SpaceWireR/SpaceWireRTransmitTEP.hh
@@ -36,10 +36,10 @@
 
 #include "SpaceWireR/SpaceWireRTEP.hh"
 
-#define DebugSpaceWireRTransmitTEP
-#define DebugSpaceWireRTransmitTEPDumpCriticalIncidents
-//#undef DebugSpaceWireRTransmitTEP
-//#undef DebugSpaceWireRTransmitTEPDumpCriticalIncidents
+//#define DebugSpaceWireRTransmitTEP
+//#define DebugSpaceWireRTransmitTEPDumpCriticalIncidents
+#undef DebugSpaceWireRTransmitTEP
+#undef DebugSpaceWireRTransmitTEPDumpCriticalIncidents
 
 class SpaceWireRTransmitTEP: public SpaceWireRTEP, public CxxUtilities::StoppableThread {
 

--- a/includes/SpaceWireSpacePiModule.hh
+++ b/includes/SpaceWireSpacePiModule.hh
@@ -1,0 +1,357 @@
+#ifndef SPACEWIRESPACEPIMODULE_HH_
+#define SPACEWIRESPACEPIMODULE_HH_
+
+#include "CxxUtilities/Exception.hh"
+#include <wiringPi.h>
+#include <bcm2835.h>
+#include <sys/time.h>
+#include <iostream>
+#include <pthread.h>
+
+#define TIMEOUT_MILLISEC_DEFAULT 1000
+
+//#define DebugSpaceWireSpacePiModule
+#undef DebugSpaceWireSpacePiModule
+
+using namespace std;
+
+// dummy function, now interrupt is checked with polling
+void fpga_int(){
+}
+
+class SpaceWireSpacePiException: public CxxUtilities::Exception{
+    public:
+        enum{
+            DataSizeTooLarge,
+            Disconnected,
+            Timeout,
+            Undefined,
+        };
+
+    public:
+        SpaceWireSpacePiException(uint32_t status):
+            CxxUtilities::Exception(status){
+            }
+
+    public:
+        virtual ~SpaceWireSpacePiException(){}
+
+    public:
+        string toString(){
+            string result;
+            switch(status){
+                case DataSizeTooLarge:
+                    result = "DataSizeTooLarge";
+                    break;
+                case Disconnected:
+                    result = "Disconnected";
+                    break;
+                case Timeout:
+                    result = "Timeout";
+                    break;
+                case Undefined:
+                    result = "Undefined";
+                    break;
+
+                default:
+                    result = "Undefined status";
+                    break;
+            }
+            return result;
+        }
+};
+
+class SpaceWireSpacePiModule {
+
+    enum EOPType {
+        EOP = 0x00, EEP = 0x01, Undefined = 0xffff
+    };
+
+    public:
+    SpaceWireSpacePiModule(){
+    };
+
+    ~SpaceWireSpacePiModule(){};
+
+    long timeout_duration_millisec;
+    pthread_mutex_t mutex;
+
+    public:
+    int32_t open(void){
+        // SPI初期化
+        if ( !bcm2835_init()) return -1;
+
+        bcm2835_spi_begin();
+        bcm2835_spi_setBitOrder(BCM2835_SPI_BIT_ORDER_MSBFIRST);
+        bcm2835_spi_setDataMode(BCM2835_SPI_MODE0);
+        bcm2835_spi_setClockDivider(BCM2835_SPI_CLOCK_DIVIDER_32);
+        bcm2835_spi_chipSelect(BCM2835_SPI_CS0);
+        bcm2835_spi_setChipSelectPolarity(BCM2835_SPI_CS0, LOW);
+
+        // interrupt
+        int ret;
+        ret = wiringPiSetupSys();
+        if ( ret < 0 ) {
+            printf("Interrupt setup error\n");
+            return ret;
+        }else {
+            wiringPiISR( 27, INT_EDGE_RISING, fpga_int );		// GPIO27 interrupt setting
+            pinMode(27, INPUT);
+            // printf("Interrupt setup OK\n");
+        }
+
+        timeout_duration_millisec = TIMEOUT_MILLISEC_DEFAULT;
+        pthread_mutex_init(&mutex, NULL);
+
+        return 0;
+    }
+
+    public:
+    void close(void){
+        // TODO:割り込み処理の停止
+
+        // TODO:ハンドラスレッドの終了
+
+        // SPIの終了
+        bcm2835_spi_end();
+        bcm2835_close();
+    }
+
+    /*
+     * SpacePi の送信バッファへbufのデータを送信する
+     * 
+     * uint8_t *buf 送信データバッファ
+     * uint32_t len 送信データ長
+     * uint32_t type 送信データの終端の種類（）
+     */
+    public:
+    //extern int32_t spacepi_send(uint8_t *buf, size_t len, enum EOPType type);
+    int32_t send(uint8_t *buf, size_t len){
+
+        enum EOPType type = EOP;  //TODO
+        uint8_t SpiTxData[2048];	// SPI送信データ
+
+
+        // SPI フォーマット（Cmd, Address）
+        char tx_sts_read[] = { 0x20, 0x00, 0x00, 0x00 };  // リード、Txバッファステータス
+        char tx_snd_eop[] = { 0xA0, 0x02, 0x01, 0x00 };	  // ライト、Txバッファコントロール、EOP送信コマンド
+        char tx_snd_eep[] = { 0xA0, 0x02, 0x03, 0x00 };	  // ライト、Txバッファコントロール、EEP送信コマンド
+
+        pthread_mutex_lock(&mutex);
+        spi_transfer(&tx_sts_read[0], sizeof(tx_sts_read)); // Read Tx buffer status
+
+        //debug
+        unsigned int tx_buf_cap = (((unsigned int)tx_sts_read[3] << 8) & 0x0F00) | ((unsigned int)tx_sts_read[2]);
+#ifdef DebugSpaceWireSpacePiModule
+        printf("SpacePiModule::send() tx_sts_read[3]=0x%02X, [2]=0x%02X\n",tx_sts_read[3], tx_sts_read[2]);
+        if(tx_sts_read[3] != 0x08){
+            int i;
+            for(i=0;i<len;++i){
+                printf("%02X ", buf[i]);
+            }
+            printf("\n");
+        }
+#endif
+
+        // Tx buffer empty
+        if (tx_buf_cap == 0x800) {
+
+            spi_cre_write_packet(&SpiTxData[0], 0x0000, len, buf);
+
+#if 0
+            int cnt;
+            printf("len=%d\n",len);
+            for ( cnt=0; cnt<len; cnt++ ) {
+                printf("%02X ",SpiTxData[cnt]);
+                if ((cnt%16)==15 ) printf("\n");
+            }
+            printf("\n");
+#endif
+
+            // Write SpaceWire data to Tx Buffer
+#ifdef DebugSpaceWireSpacePiModule
+            printf("SpacePiModule::send() Sending data to Tx buffer...\n");
+#endif
+            spi_transfer(&SpiTxData[0], len+2);
+
+            // Write SpaceWire end of packet to Tx buffer control
+#ifdef DebugSpaceWireSpacePiModule
+            printf("SpacePiModule::send() SPI send command...\n");
+#endif
+            if(type == EEP) {
+                spi_transfer(&tx_snd_eep[0], sizeof(tx_snd_eop));
+            } else {
+                spi_transfer(&tx_snd_eop[0], sizeof(tx_snd_eop));
+            }
+            pthread_mutex_unlock(&mutex);
+#ifdef DebugSpaceWireSpacePiModule
+            printf("SpacePiModule::send() SPI send finished\n");
+#endif
+
+        } else {
+            printf("SpacePiModule::send() SpacePi TxBuffer is not empty.\n");
+            printf("SpacePiModule::send() Tx buffer cap: %d/2048 [byte]\n", tx_buf_cap);
+            return -1;
+        }
+
+        return 0;
+
+    }
+
+    /*
+     *
+     * @ [OUT]rx_data　
+     * @ [INOUT]rx_size IN: 呼び出し元が確保したサイズ、　OUT：SpacePiから格納したサイズ
+     *
+     */
+    public:
+    //extern int spacepi_receive(uint8_t *buf, size_t len, enum type);
+    int receive(uint8_t *rx_data, size_t *rx_size) throw (SpaceWireSpacePiException) {
+        char buf[16];
+        const char rx_sts_rd[] = { 0x20, 0x10, 0x00, 0x00 };		// Rxバッファステータス読込み
+        const char tx_int_clr[] = { 0xA0, 0x12, 0x01, 0x00 };		// Txバッファ 受信割込みクリア
+        const char* packet_end[] = {"EOP","EEP","Continue","Reserved"};
+        size_t size;
+        struct timeval tv_start, tv_now;
+
+        int rcv_flg = 1;
+        long elapsed_time = 0;
+
+#ifdef DebugSpaceWireSpacePiModule
+        printf("SpacePiModule::receive() entered.\n");
+#endif
+        gettimeofday(&tv_start, NULL);
+
+        while(rcv_flg) {
+
+            usleep(1);
+            gettimeofday(&tv_now, NULL);
+            long dt_us = (tv_now.tv_sec - tv_start.tv_sec) * 1000000 + (tv_now.tv_usec - tv_start.tv_usec);
+
+            if(dt_us > timeout_duration_millisec * 1000){
+                *rx_size = 0;
+                throw SpaceWireSpacePiException(SpaceWireSpacePiException::Timeout);
+            }
+
+            // FPGA割込みチェック
+            if ( digitalRead(27) ) {						// 受信ありのとき
+
+                memcpy(&buf[0], &rx_sts_rd[0], 4);
+                pthread_mutex_lock(&mutex);
+                spi_transfer(&buf[0], 4);			// 受信ステータス取得
+
+                char rx_packet_end = ((buf[3]&0xC0)>>6)&0x03;
+                // 受信サイズを格納
+                size = ((short)buf[3]<<8) & 0x0F00;
+                size = size | (buf[2] & 0xFF);
+#ifdef DebugSpaceWireSpacePiModule
+                printf("SpacePiModule::receive() pkt with %s received: %d [byte]\n",packet_end[rx_packet_end], size);
+#endif
+
+                if ((buf[3]&0xC0) == 0 ) {
+                    // EOPパケット受信のとき
+
+                    // sizeが確保したバッファサイズよりも小さい場合は、sizeの大きさに変更する
+                    if(size < *rx_size) {
+                        *rx_size = size;
+                    }
+
+                    // 受信データを確保
+                    memset(&rx_data[0], 0x00, *rx_size+3);
+                    rx_data[0] = 0x08;								// 0x0800=Recive Buffer
+#ifdef DebugSpaceWireSpacePiModule
+                    printf("SpacePiModule::receive() SPI getting Rx buffer...\n");
+#endif
+                    spi_transfer(&rx_data[0], *rx_size+2);
+#ifdef DebugSpaceWireSpacePiModule
+                    printf("SpacePiModule::receive() SPI getting Rx buffer Done\n");
+#endif
+                }else{
+                    //EOP以外のとき
+                    printf("SpacePiModule: Invalid Packet Received!!\n");
+                }
+
+                // SPI Interrupt clear
+#ifdef DebugSpaceWireSpacePiModule
+                printf("SpacePiModule::receive() Clearing intterupt flag...\n");
+#endif
+                memcpy(&buf[0], &tx_int_clr[0], 4);
+                spi_transfer(&buf[0], 4);		// 割込みクリア
+                pthread_mutex_unlock(&mutex);
+#ifdef DebugSpaceWireSpacePiModule
+                printf("SpacePiModule::receive() Clearing intterupt flag done.\n");
+#endif
+
+                rcv_flg = 0;
+            }
+        }
+
+        //int cnt;
+        //printf("rx_size=%d\n",*rx_size);
+        //for ( cnt=0; cnt<*rx_size; cnt++ ) {
+        //	printf("%02X ",rx_data[cnt]);
+        //	if ((cnt%16)==15)printf("\n");
+        //}
+        //printf("\n");
+
+        return 0;
+
+    }
+
+
+    // internal function
+    private:
+    void spi_transfer(void *buf, uint32_t len){
+
+        bcm2835_spi_chipSelect(BCM2835_SPI_CS0);
+        bcm2835_spi_transfern((char *)buf, len);
+
+    }
+
+    /*
+     * SPIの書込みコマンド作成
+     */
+    private:
+    int32_t spi_cre_write_packet(uint8_t *buf, uint16_t addr, size_t length, uint8_t *write_data)
+    {
+        if ( length > 2046 ) return -1;
+
+        addr = addr | 0x8000;		// Command(Write)
+        buf[0] = (addr >> 8) & 0xFF;
+        buf[1] = addr & 0xFF;
+
+        memcpy( &buf[2], write_data, length);
+
+        length = 2 + length;			// Command + Address = 2 + read length
+
+        return 0;
+    }
+
+    /*
+     * SPIの読込みコマンド作成
+     */
+    private:
+    uint32_t spi_cre_read_packet(uint8_t *buf, uint16_t addr, uint32_t length)
+    {
+        memset(&buf[0], 0x00, 2048);
+
+        addr = addr & 0x7FFF;				// Command(Read)
+        buf[0] = (addr >> 8) & 0xFF;
+        buf[1]  = addr & 0xFF;
+
+        length = 2 + length;		// Command + Address = 2 + read length
+
+        return 0;
+    }
+
+    /*
+     * SPI readのタイムアウト設定
+     */
+    public:
+    void setTimeout(long millisecond){
+        timeout_duration_millisec = millisecond;
+    }
+};
+
+
+#endif 


### PR DESCRIPTION
Contents
* Applied [SpaceWire-R Draft 0.4](http://spacewire.esa.int/content/Standard/documents/SpW-R%2004.pdf) (fixed SequenceNumber of Heartbeat to 0x00)
* Added libraries for Shimafuji SpacePi (SpaceWire.hh, SpaceWireIFOverSPI.hh, SpaceWireSpacePiModule.hh)
* SpaceWire-R RTEP packet receive bugfix

How to use
* When using SpacePi(+RaspberryPi), add -DRASPBERRY_PI to make.